### PR TITLE
A null value is valid

### DIFF
--- a/DataTables.Mvc/Search.cs
+++ b/DataTables.Mvc/Search.cs
@@ -50,7 +50,7 @@ namespace DataTables.Mvc
         /// <exception cref="System.ArgumentNullException">Thrown when the provided search value is null.</exception>
         public Search(string value, bool isRegexValue)
         {
-            if (value == null) throw new ArgumentNullException("value", "The value of the search cannot be null. If there's no search performed, provide an empty string.");
+            //if (value == null) throw new ArgumentNullException("value", "The value of the search cannot be null. If there's no search performed, provide an empty string.");
             
             this.Value = value;
             this.IsRegexValue = isRegexValue;


### PR DESCRIPTION
When setting the javascript option "searching" to "false", the search value is null and throws an exception.  Removing the validation makes it work properly.  It is up to the dev to validate that the value has a value or is null.

fixes #16 